### PR TITLE
Add home page grid view data binding

### DIFF
--- a/src/TerminalSettings/TerminalSettings/Home.cpp
+++ b/src/TerminalSettings/TerminalSettings/Home.cpp
@@ -28,9 +28,7 @@ namespace winrt::SettingsControl::implementation
 
     void Home::OnHomeGridItemClick(IInspectable const& sender, RoutedEventArgs const& args)
     {
-        // This doesn't work
-        auto gridView = HomeGridView();
-        HomeViewModel().HomeGridItem().Title(L"CLICKED");
+
     }
 
     SettingsControl::SettingsControlViewModel Home::HomeViewModel()

--- a/src/TerminalSettings/TerminalSettings/Home.cpp
+++ b/src/TerminalSettings/TerminalSettings/Home.cpp
@@ -9,11 +9,33 @@ namespace winrt::SettingsControl::implementation
 {
     Home::Home()
     {
+        m_homeViewModel = winrt::make<SettingsControl::implementation::SettingsControlViewModel>();
         InitializeComponent();
+
+        HomeViewModel().HomeGridItems().Append(winrt::make<SettingsControl::implementation::HomeGridItem>(L"Launch"));
+        HomeViewModel().HomeGridItems().Append(winrt::make<SettingsControl::implementation::HomeGridItem>(L"Interaction"));
+        HomeViewModel().HomeGridItems().Append(winrt::make<SettingsControl::implementation::HomeGridItem>(L"Rendering"));
+        HomeViewModel().HomeGridItems().Append(winrt::make<SettingsControl::implementation::HomeGridItem>(L"Global appearance"));
+        HomeViewModel().HomeGridItems().Append(winrt::make<SettingsControl::implementation::HomeGridItem>(L"Color Schemes"));
+        HomeViewModel().HomeGridItems().Append(winrt::make<SettingsControl::implementation::HomeGridItem>(L"Global profile settings"));
+        HomeViewModel().HomeGridItems().Append(winrt::make<SettingsControl::implementation::HomeGridItem>(L"Keyboard"));
     }
 
     void Home::ClickHandler(IInspectable const&, RoutedEventArgs const&)
     {
+
+    }
+
+    void Home::OnHomeGridItemClick(IInspectable const& sender, RoutedEventArgs const& args)
+    {
+        // This doesn't work
+        auto gridView = HomeGridView();
+        HomeViewModel().HomeGridItem().Title(L"CLICKED");
+    }
+
+    SettingsControl::SettingsControlViewModel Home::HomeViewModel()
+    {
+        return m_homeViewModel;
     }
 
 }

--- a/src/TerminalSettings/TerminalSettings/Home.h
+++ b/src/TerminalSettings/TerminalSettings/Home.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "Home.g.h"
+#include "SettingsControlViewModel.h"
 
 namespace winrt::SettingsControl::implementation
 {
@@ -8,7 +9,13 @@ namespace winrt::SettingsControl::implementation
     {
         Home();
 
+        SettingsControl::SettingsControlViewModel HomeViewModel();
+
         void ClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
+        void OnHomeGridItemClick(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
+
+        private:
+        SettingsControl::SettingsControlViewModel m_homeViewModel{ nullptr };
     };
 }
 

--- a/src/TerminalSettings/TerminalSettings/Home.idl
+++ b/src/TerminalSettings/TerminalSettings/Home.idl
@@ -1,8 +1,10 @@
+import "SettingsControlViewModel.idl";
+
 namespace SettingsControl
 {
-    [default_interface]
     runtimeclass Home : Windows.UI.Xaml.Controls.Page
     {
         Home();
+        SettingsControlViewModel HomeViewModel{ get; };
     }
 }

--- a/src/TerminalSettings/TerminalSettings/Home.xaml
+++ b/src/TerminalSettings/TerminalSettings/Home.xaml
@@ -23,28 +23,38 @@
                    TextAlignment="Center"
                    Margin="0,0,0,20" />
         <GridView Grid.Row="1"
-                  ItemContainerStyle="{StaticResource GridViewItemStyle}">
-            <GridViewItem Height="150" Width="300">
-                <TextBlock Text="Launch" Style="{StaticResource TitleTextBlockStyle}"/>
-            </GridViewItem>
-            <GridViewItem Height="150" Width="300">
-                <TextBlock Text="Interaction" Style="{StaticResource TitleTextBlockStyle}"/>
-            </GridViewItem>
-            <GridViewItem Height="150" Width="300">
-                <TextBlock Text="Rendering" Style="{StaticResource TitleTextBlockStyle}"/>
-            </GridViewItem>
-            <GridViewItem Height="150" Width="300">
-                <TextBlock Text="Global Appearance" Style="{StaticResource TitleTextBlockStyle}"/>
-            </GridViewItem>
-            <GridViewItem Height="150" Width="300">
-                <TextBlock Text="Color Schemes" Style="{StaticResource TitleTextBlockStyle}"/>
-            </GridViewItem>
-            <GridViewItem Height="150" Width="300">
-                <TextBlock Text="Profiles" Style="{StaticResource TitleTextBlockStyle}"/>
-            </GridViewItem>
-            <GridViewItem Height="150" Width="300">
-                <TextBlock Text="Keyboard" Style="{StaticResource TitleTextBlockStyle}"/>
-            </GridViewItem>
+                  x:Name="HomeGridView"
+                  ItemsSource="{x:Bind HomeViewModel.HomeGridItems}"
+                  ItemContainerStyle="{StaticResource GridViewItemStyle}"
+                  IsItemClickEnabled="True"
+                  ItemClick="OnHomeGridItemClick">
+            <GridView.ItemTemplate>
+                <DataTemplate x:DataType="local:HomeGridItem">
+                    <UserControl>
+                        <Grid
+                        x:Name="homeGridItemRoot"
+                        Width="344"
+                        Height="140"
+                        Padding="12"
+                        Background="{ThemeResource SystemControlBackgroundListLowBrush}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <RelativePanel Grid.Column="1" Grid.ColumnSpan="2" Margin="16,6,0,0">
+                                <TextBlock
+                                x:Name="titleText"
+                                Style="{StaticResource SubheaderTextBlockStyle}"
+                                Text="{x:Bind Title}"
+                                Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                                TextLineBounds="TrimToCapHeight"
+                                TextWrapping="NoWrap" />
+                            </RelativePanel>
+                        </Grid>
+                    </UserControl>
+                </DataTemplate>
+            </GridView.ItemTemplate>
         </GridView>
     </Grid>
 </Page>

--- a/src/TerminalSettings/TerminalSettings/Home.xaml
+++ b/src/TerminalSettings/TerminalSettings/Home.xaml
@@ -26,8 +26,7 @@
                   x:Name="HomeGridView"
                   ItemsSource="{x:Bind HomeViewModel.HomeGridItems}"
                   ItemContainerStyle="{StaticResource GridViewItemStyle}"
-                  IsItemClickEnabled="True"
-                  ItemClick="OnHomeGridItemClick">
+                  IsItemClickEnabled="True">
             <GridView.ItemTemplate>
                 <DataTemplate x:DataType="local:HomeGridItem">
                     <UserControl>

--- a/src/TerminalSettings/TerminalSettings/HomeGridItem.cpp
+++ b/src/TerminalSettings/TerminalSettings/HomeGridItem.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "HomeGridItem.h"
+#include "HomeGridItem.g.cpp"
+
+namespace winrt::SettingsControl::implementation
+{
+    HomeGridItem::HomeGridItem(hstring const& title) : m_title { title }
+    {
+    }
+    hstring HomeGridItem::Title()
+    {
+        return m_title;
+    }
+    void HomeGridItem::Title(hstring const& value)
+    {
+        if (m_title != value)
+        {
+            m_title = value;
+            m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Title" });
+        }
+    }
+    winrt::event_token HomeGridItem::PropertyChanged(Windows::UI::Xaml::Data::PropertyChangedEventHandler const& handler)
+    {
+        return m_propertyChanged.add(handler);
+    }
+    void HomeGridItem::PropertyChanged(winrt::event_token const& token)
+    {
+        m_propertyChanged.remove(token);
+    }
+}

--- a/src/TerminalSettings/TerminalSettings/HomeGridItem.h
+++ b/src/TerminalSettings/TerminalSettings/HomeGridItem.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "HomeGridItem.g.h"
+
+namespace winrt::SettingsControl::implementation
+{
+    struct HomeGridItem : HomeGridItemT<HomeGridItem>
+    {
+        HomeGridItem() = delete;
+        HomeGridItem(hstring const& title);
+
+        hstring Title();
+        void Title(hstring const& value);
+        winrt::event_token PropertyChanged(Windows::UI::Xaml::Data::PropertyChangedEventHandler const& value);
+        void PropertyChanged(winrt::event_token const& token);
+
+        private:
+        hstring m_title;
+        event<Windows::UI::Xaml::Data::PropertyChangedEventHandler> m_propertyChanged; 
+    };
+}

--- a/src/TerminalSettings/TerminalSettings/HomeGridItem.idl
+++ b/src/TerminalSettings/TerminalSettings/HomeGridItem.idl
@@ -1,0 +1,7 @@
+namespace SettingsControl
+{
+    runtimeclass HomeGridItem : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    {
+        String Title;
+    }
+}

--- a/src/TerminalSettings/TerminalSettings/SettingsControl.vcxproj
+++ b/src/TerminalSettings/TerminalSettings/SettingsControl.vcxproj
@@ -120,6 +120,7 @@
     <ClInclude Include="Home.h">
       <DependentUpon>Home.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="HomeGridItem.h" />
     <ClInclude Include="Interaction.h">
       <DependentUpon>Interaction.xaml</DependentUpon>
     </ClInclude>
@@ -231,6 +232,7 @@
     <ClCompile Include="Home.cpp">
       <DependentUpon>Home.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="HomeGridItem.cpp" />
     <ClCompile Include="Interaction.cpp">
       <DependentUpon>Interaction.xaml</DependentUpon>
     </ClCompile>
@@ -283,6 +285,7 @@
       <DependentUpon>Globals.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
+    <Midl Include="HomeGridItem.idl" />
     <Midl Include="Launch.idl">
       <DependentUpon>Launch.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/src/TerminalSettings/TerminalSettings/SettingsControl.vcxproj
+++ b/src/TerminalSettings/TerminalSettings/SettingsControl.vcxproj
@@ -149,6 +149,7 @@
     <ClInclude Include="Rendering.h">
       <DependentUpon>Rendering.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="SettingsControlViewModel.h" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -264,6 +265,7 @@
     <ClCompile Include="Rendering.cpp">
       <DependentUpon>Rendering.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="SettingsControlViewModel.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="App.idl">
@@ -313,6 +315,7 @@
       <DependentUpon>AddProfile.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
+    <Midl Include="SettingsControlViewModel.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/TerminalSettings/TerminalSettings/SettingsControl.vcxproj.filters
+++ b/src/TerminalSettings/TerminalSettings/SettingsControl.vcxproj.filters
@@ -20,6 +20,7 @@
     <Midl Include="App.idl" />
     <Midl Include="MainPage.idl" />
     <Midl Include="HomeGridItem.idl" />
+    <Midl Include="SettingsControlViewModel.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -39,6 +40,7 @@
       <Filter>ObjectModel</Filter>
     </ClCompile>
     <ClCompile Include="HomeGridItem.cpp" />
+    <ClCompile Include="SettingsControlViewModel.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -55,6 +57,7 @@
       <Filter>ObjectModel</Filter>
     </ClInclude>
     <ClInclude Include="HomeGridItem.h" />
+    <ClInclude Include="SettingsControlViewModel.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Wide310x150Logo.scale-200.png">

--- a/src/TerminalSettings/TerminalSettings/SettingsControl.vcxproj.filters
+++ b/src/TerminalSettings/TerminalSettings/SettingsControl.vcxproj.filters
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Midl Include="App.idl" />
     <Midl Include="MainPage.idl" />
+    <Midl Include="HomeGridItem.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -37,6 +38,7 @@
     <ClCompile Include="ObjectModel\Profile.cpp">
       <Filter>ObjectModel</Filter>
     </ClCompile>
+    <ClCompile Include="HomeGridItem.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -52,6 +54,7 @@
     <ClInclude Include="ObjectModel\Profile.h">
       <Filter>ObjectModel</Filter>
     </ClInclude>
+    <ClInclude Include="HomeGridItem.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Wide310x150Logo.scale-200.png">

--- a/src/TerminalSettings/TerminalSettings/SettingsControlViewModel.cpp
+++ b/src/TerminalSettings/TerminalSettings/SettingsControlViewModel.cpp
@@ -6,7 +6,6 @@ namespace winrt::SettingsControl::implementation
 {
     SettingsControlViewModel::SettingsControlViewModel()
     {
-        m_homegriditem = winrt::make<SettingsControl::implementation::HomeGridItem>(L"");
         m_homegriditems = winrt::single_threaded_observable_vector<SettingsControl::HomeGridItem>();
     }
 

--- a/src/TerminalSettings/TerminalSettings/SettingsControlViewModel.cpp
+++ b/src/TerminalSettings/TerminalSettings/SettingsControlViewModel.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+#include "SettingsControlViewModel.h"
+#include "SettingsControlViewModel.g.cpp"
+
+namespace winrt::SettingsControl::implementation
+{
+    SettingsControlViewModel::SettingsControlViewModel()
+    {
+        m_homegriditem = winrt::make<SettingsControl::implementation::HomeGridItem>(L"");
+        m_homegriditems = winrt::single_threaded_observable_vector<SettingsControl::HomeGridItem>();
+    }
+
+    SettingsControl::HomeGridItem SettingsControlViewModel::HomeGridItem()
+    {
+        return m_homegriditem;
+    }
+
+    Windows::Foundation::Collections::IObservableVector<SettingsControl::HomeGridItem> SettingsControlViewModel::HomeGridItems()
+    {
+        return m_homegriditems;
+    }
+}

--- a/src/TerminalSettings/TerminalSettings/SettingsControlViewModel.h
+++ b/src/TerminalSettings/TerminalSettings/SettingsControlViewModel.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "SettingsControlViewModel.g.h"
+#include "HomeGridItem.h"
+
+namespace winrt::SettingsControl::implementation
+{
+    struct SettingsControlViewModel : SettingsControlViewModelT<SettingsControlViewModel>
+    {
+        SettingsControlViewModel();
+
+        SettingsControl::HomeGridItem HomeGridItem();
+
+        Windows::Foundation::Collections::IObservableVector<SettingsControl::HomeGridItem> HomeGridItems();
+
+        private:
+            SettingsControl::HomeGridItem m_homegriditem{ nullptr };
+            Windows::Foundation::Collections::IObservableVector<SettingsControl::HomeGridItem> m_homegriditems;
+    };
+}

--- a/src/TerminalSettings/TerminalSettings/SettingsControlViewModel.idl
+++ b/src/TerminalSettings/TerminalSettings/SettingsControlViewModel.idl
@@ -1,0 +1,10 @@
+import "HomeGridItem.idl";
+
+namespace SettingsControl
+{
+    runtimeclass SettingsControlViewModel
+    {
+        HomeGridItem HomeGridItem{ get; };
+        Windows.Foundation.Collections.IObservableVector<HomeGridItem> HomeGridItems{ get; };
+    }
+}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The home page now reads a vector for the GridView items.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
